### PR TITLE
Added option to omit excpetion edges in CFG

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ To create a png file showing the CFG of a js file:
 ```js
 var esgraph = require('esgraph');
 
-var cfg = esgraph(esprima.parse(source, {range: true}));
+var cfg = esgraph(esprima.parse(source, {range: true}), {
+        // do not create edges for non-explicit exceptions (default: false)
+        omitExceptions: false
+    }
+);
 // cfg[0] is the start node
 // cfg[1] is the end node
 // cfg[2] is an array of all nodes for easier iteration

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,10 +17,12 @@ module.exports.dot = require('./dot');
 /**
  * Returns [entry, exit] `FlowNode`s for the passed in AST
  */
-function ControlFlowGraph(astNode) {
+function ControlFlowGraph(astNode, options) {
+	options = options || {};
 	var parentStack = [];
 	var exitNode = new FlowNode(undefined, undefined, 'exit');
 	var catchStack = [exitNode];
+	var omitExceptions = !!options.omitExceptions;
 
 	createNodes(astNode);
 	linkSiblings(astNode);
@@ -167,7 +169,7 @@ function ControlFlowGraph(astNode) {
 	}
 
 	function mayThrow(node) {
-		if (expressionThrows(node))
+		if (!omitExceptions && expressionThrows(node))
 			node.cfg.connect(getExceptionTarget(node), 'exception');
 	}
 	function expressionThrows(astNode) {

--- a/test/test.js
+++ b/test/test.js
@@ -35,6 +35,18 @@ describe('esgraph', function () {
 		var cfg = esgraph(ast);
 		esgraph.dot(cfg);
 	});
+
+	it('should omit implicit exception edges when omitExceptions option is set', function () {
+		var contents = fs.readFileSync(dir + "basicblocks.js", 'utf8');
+		var ast = espree.parse(contents, {comment: true, range: true});
+		delete ast.comments;
+
+		var cfg = esgraph(ast);
+		cfg[1].prev.length.should.equal(2);
+
+		cfg = esgraph(ast, {omitExceptions: true});
+		cfg[1].prev.length.should.equal(1);
+	});
 });
 
 describe('esgraph.dot', function () {


### PR DESCRIPTION
Pass { omitExceptions: true } as second argument to esgraph ControlFlowGraph

It's usefull if excpetions should not be considered, either by the analysis or just for display purposes.
